### PR TITLE
Support ESM loading by forcing all imports to be modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pnpm-lock.yaml
 playwright-report
 test-results
 *.tgz
+package-lock.json

--- a/rewriter/js/src/cfg.rs
+++ b/rewriter/js/src/cfg.rs
@@ -9,6 +9,7 @@ pub trait UrlRewriter {
 		flags: &Flags,
 		url: &str,
 		builder: &mut StringBuilder,
+		module: bool,
 	) -> Result<(), Box<dyn Error + Sync + Send>>;
 }
 

--- a/rewriter/js/src/visitor.rs
+++ b/rewriter/js/src/visitor.rs
@@ -52,13 +52,13 @@ impl<'data, E> Visitor<'_, 'data, E>
 where
 	E: UrlRewriter,
 {
-	fn rewrite_url(&mut self, url: &StringLiteral<'data>) {
+	fn rewrite_url(&mut self, url: &StringLiteral<'data>, module: bool) {
 		let mut builder = StringBuilder::from_str_in(&self.config.prefix, self.alloc);
 		if self.error.is_some() {
 			builder.push_str("__URL_REWRITER_ALREADY_ERRORED__");
 		} else if let Err(err) =
 			self.rewriter
-				.rewrite(self.config, &self.flags, &url.value, &mut builder)
+				.rewrite(self.config, &self.flags, &url.value, &mut builder,module)
 		{
 			self.error.replace(err);
 			builder.push_str("__URL_REWRITER_ERROR__");
@@ -184,7 +184,7 @@ where
 	}
 
 	fn visit_import_declaration(&mut self, it: &ImportDeclaration<'data>) {
-		self.rewrite_url(&it.source);
+		self.rewrite_url(&it.source,true);
 		walk::walk_import_declaration(self, it);
 	}
 	fn visit_import_expression(&mut self, it: &ImportExpression<'data>) {
@@ -196,11 +196,11 @@ where
 	}
 
 	fn visit_export_all_declaration(&mut self, it: &ExportAllDeclaration<'data>) {
-		self.rewrite_url(&it.source);
+		self.rewrite_url(&it.source,true);
 	}
 	fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'data>) {
 		if let Some(source) = &it.source {
-			self.rewrite_url(source);
+			self.rewrite_url(source,true);
 		}
 		// do not walk further, we don't want to rewrite the identifiers
 	}

--- a/rewriter/native/src/rewriter.rs
+++ b/rewriter/native/src/rewriter.rs
@@ -21,6 +21,7 @@ impl UrlRewriter for NativeUrlRewriter {
 		flags: &Flags,
 		url: &str,
 		builder: &mut StringBuilder,
+		_module: bool,
 	) -> Result<(), Box<dyn Error + Sync + Send>> {
 		let base = Url::from_str(&flags.base)?;
 		builder.push_str(encode(base.join(url)?.as_str()).as_ref());

--- a/rewriter/wasm/Cargo.toml
+++ b/rewriter/wasm/Cargo.toml
@@ -15,7 +15,7 @@ oxc = { workspace = true }
 js = { version = "0.1.0", path = "../js", default-features = false }
 thiserror = "2.0.12"
 wasm-bindgen = "0.2.100"
-web-sys = { version = "0.3.77", features = ["Url"] }
+web-sys = { version = "0.3.77", features = ["Url","UrlSearchParams"] }
 html = { version = "0.1.0", path = "../html" }
 
 [features]

--- a/rewriter/wasm/src/jsr.rs
+++ b/rewriter/wasm/src/jsr.rs
@@ -74,17 +74,33 @@ impl UrlRewriter for WasmUrlRewriter {
 			.map_err(RewriterError::from)?
 			.to_string();
 
-		builder.push_str(
-			self.0
-				.call1(&JsValue::NULL, &url.into())
-				.map_err(RewriterError::from)?
-				.as_string()
-				.ok_or_else(|| RewriterError::not_str("url rewriter output"))?
-				.as_str(),
-		);
 		if module {
-			builder.push_str(if builder.contains("?") { "&" } else { "?" });
-			builder.push_str("type=module");
+			let url = Url::new(
+				self.0
+					.call1(&JsValue::NULL, &url.into())
+					.map_err(RewriterError::from)?
+					.as_string()
+					.ok_or_else(|| RewriterError::not_str("url rewriter output"))?
+					.as_str(),
+			)
+			.map_err(RewriterError::from)?;
+			// builder.push_str(if builder.contains("?") { "&" } else { "?" });
+			// builder.push_str("type=module");
+			url.search_params().append("type", "module");
+			builder.push_str(
+				&url.to_string()
+					.as_string()
+					.unwrap_or_else(|| format!("URL UNKNOWN")),
+			);
+		} else {
+			builder.push_str(
+				self.0
+					.call1(&JsValue::NULL, &url.into())
+					.map_err(RewriterError::from)?
+					.as_string()
+					.ok_or_else(|| RewriterError::not_str("url rewriter output"))?
+					.as_str(),
+			);
 		}
 
 		Ok(())

--- a/rewriter/wasm/src/jsr.rs
+++ b/rewriter/wasm/src/jsr.rs
@@ -68,6 +68,7 @@ impl UrlRewriter for WasmUrlRewriter {
 		flags: &Flags,
 		url: &str,
 		builder: &mut StringBuilder,
+		module: bool,
 	) -> std::result::Result<(), Box<dyn Error + Sync + Send>> {
 		let url = Url::new_with_base(url, &flags.base)
 			.map_err(RewriterError::from)?
@@ -81,6 +82,10 @@ impl UrlRewriter for WasmUrlRewriter {
 				.ok_or_else(|| RewriterError::not_str("url rewriter output"))?
 				.as_str(),
 		);
+		if module {
+			builder.push_str(if builder.contains("?") { "&" } else { "?" });
+			builder.push_str("type=module");
+		}
 
 		Ok(())
 	}


### PR DESCRIPTION
Might solve [this](https://github.com/MercuryWorkshop/scramjet/issues/28#:~:text=Bahn%2DVorhersage%20(https%3A//bahnvorhersage.de/)%0AWith%20other%20proxies%20it%20gets%20a%20reference%20to%20the%20URL%2C%20but%20with%20Scramjet%20it%20just%20fails%20to%20set%20itself%20up%20in%20the%20DOM%20%2D%20explained%20in%20later%20comments)