### PR TITLE
fix: support the WASM rewriter build script on OS that use BSD utilities

### DIFF
--- a/rewriter/wasm/build.sh
+++ b/rewriter/wasm/build.sh
@@ -36,7 +36,11 @@ fi
 )
 wasm-bindgen --target web --out-dir out/ ../target/wasm32-unknown-unknown/release/wasm.wasm
 
-sed -i 's/import.meta.url/""/g' out/wasm.js
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "freebsd"* ]] || [[ "$OSTYPE" == "dragonfly"* ]]; then
+	sed -i '' 's/import.meta.url/""/g' out/wasm.js
+else
+	sed -i 's/import.meta.url/""/g' out/wasm.js
+fi
 
 cd ../../
 


### PR DESCRIPTION
This PR fixes the WASM rewriter build script issue on macOS, FreeBSD, and DragonFly BSD, where `sed -i` requires an empty string for an argument