### PR TITLE
feat: basic force referrer support and sec-fetch-site emulation

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,9 @@
+{
+	"lsp": {
+		"biome": {
+			"enabled": false
+		}
+	},
+	"format_on_save": "on",
+	"formatter": "language_server"
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 	},
 	"dependencies": {
 		"@mercuryworkshop/bare-mux": "^2.1.7",
+		"@webreflection/idb-map": "^0.3.2",
 		"dom-serializer": "^2.0.0",
 		"domhandler": "^5.0.3",
 		"domutils": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mercuryworkshop/bare-mux':
         specifier: ^2.1.7
         version: 2.1.7
+      '@webreflection/idb-map':
+        specifier: ^0.3.2
+        version: 0.3.2
       dom-serializer:
         specifier: ^2.0.0
         version: 2.0.0
@@ -687,6 +690,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@webreflection/idb-map@0.3.2':
+    resolution: {integrity: sha512-VLBTx6EUYF/dPdLyyjWWKxQmTWnVXTT1YJekrJUmfGxBcqEVL0Ih2EQptNG/JezkTYgJ0uSTb0yAum/THltBvQ==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3294,6 +3300,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
     optional: true
+
+  '@webreflection/idb-map@0.3.2': {}
 
   '@xtuc/ieee754@1.2.0':
     optional: true

--- a/src/shared/rewriters/headers.ts
+++ b/src/shared/rewriters/headers.ts
@@ -1,6 +1,17 @@
-import { URLMeta, rewriteUrl } from "./url";
-import { BareHeaders } from "@mercuryworkshop/bare-mux";
-const cspHeaders = [
+import type {
+	default as BareClient,
+	BareHeaders,
+} from "@mercuryworkshop/bare-mux";
+import type IDBMap from "@webreflection/idb-map";
+import { rewriteUrl, type URLMeta } from "./url";
+import { getSiteDirective } from "../security/siteTests";
+
+type StoredReferrerPolicies = IDBMap<string, string>;
+
+/**
+ * Headers for security policy features that haven't been emulated yet
+ */
+const SEC_HEADERS = new Set([
 	"cross-origin-embedder-policy",
 	"cross-origin-opener-policy",
 	"cross-origin-resource-policy",
@@ -20,29 +31,48 @@ const cspHeaders = [
 	// This needs to be emulated, but for right now it isn't that important of a feature to be worried about
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
 	"clear-site-data",
-];
+]);
 
-const urlHeaders = ["location", "content-location", "referer"];
+/**
+ * Headers that are actually URLs that need to be rewritten
+ */
+const URL_HEADERS = new Set(["location", "content-location", "referer"]);
 
 function rewriteLinkHeader(link: string, meta: URLMeta) {
 	return link.replace(/<(.*)>/gi, (match) => rewriteUrl(match, meta));
 }
 
-export function rewriteHeaders(rawHeaders: BareHeaders, meta: URLMeta) {
+/**
+ * Rewrites response headers
+ * @param rawHeaders Headers before they were rewritten
+ * @param meta Parsed Proxy URL
+ * @param client `BareClient` instance used for fetching
+ * @param isNavigationRequest Whether the request is a navigation request
+ */
+export async function rewriteHeaders(
+	rawHeaders: BareHeaders,
+	meta: URLMeta,
+	client: BareClient,
+	isNavigationRequest: boolean,
+	storedReferrerPolicies: StoredReferrerPolicies
+) {
 	const headers = {};
 
 	for (const key in rawHeaders) {
 		headers[key.toLowerCase()] = rawHeaders[key];
 	}
 
-	cspHeaders.forEach((header) => {
-		delete headers[header];
-	});
+	for (const cspHeader of SEC_HEADERS) {
+		delete headers[cspHeader];
+	}
 
-	urlHeaders.forEach((header) => {
-		if (headers[header])
-			headers[header] = rewriteUrl(headers[header]?.toString() as string, meta);
-	});
+	for (const urlHeader of URL_HEADERS) {
+		if (headers[urlHeader])
+			headers[urlHeader] = rewriteUrl(
+				headers[urlHeader]?.toString() as string,
+				meta
+			);
+	}
 
 	if (typeof headers["link"] === "string") {
 		headers["link"] = rewriteLinkHeader(headers["link"], meta);
@@ -50,6 +80,81 @@ export function rewriteHeaders(rawHeaders: BareHeaders, meta: URLMeta) {
 		headers["link"] = headers["link"].map((link) =>
 			rewriteLinkHeader(link, meta)
 		);
+	}
+
+	// Emulate the referrer policy to set it back to what it should've been without Force Referrer in place
+	if (typeof headers["referer"] === "string") {
+		const referrerUrl = new URL(headers["referer"]);
+		const storedReferrerPolicyRaw = await storedReferrerPolicies.get(
+			referrerUrl.href
+		);
+		if (storedReferrerPolicyRaw) {
+			const storedReferrerPolicy = storedReferrerPolicyRaw
+				.toLowerCase()
+				.split(",")
+				.map((rawDir) => rawDir.trim());
+			if (
+				storedReferrerPolicy.includes("no-referrer") ||
+				(storedReferrerPolicy.includes("no-referrer-when-downgrade") &&
+					meta.origin.protocol === "http:" &&
+					referrerUrl.protocol === "https:")
+			) {
+				delete headers["referer"];
+			} else if (storedReferrerPolicy.includes("origin")) {
+				headers["referer"] = referrerUrl.origin;
+			} else if (storedReferrerPolicy.includes("origin-when-cross-origin")) {
+				if (referrerUrl.origin !== meta.origin.origin) {
+					headers["referer"] = referrerUrl.origin;
+				} else {
+					headers["referer"] = referrerUrl.href;
+				}
+			} else if (storedReferrerPolicy.includes("same-origin")) {
+				if (referrerUrl.origin === meta.origin.origin) {
+					headers["referer"] = referrerUrl.href;
+				} else {
+					delete headers["referer"];
+				}
+			} else if (storedReferrerPolicy.includes("strict-origin")) {
+				if (
+					meta.origin.protocol === "http:" &&
+					referrerUrl.protocol === "https:"
+				) {
+					delete headers["referer"];
+				} else {
+					headers["referer"] = referrerUrl.origin;
+				}
+			}
+			// `strict-origin-when-cross-origin` is the default behavior anyway
+			else {
+				if (referrerUrl.origin === meta.origin.origin) {
+					headers["referer"] = referrerUrl.href;
+				} else if (
+					meta.origin.protocol === "http:" &&
+					referrerUrl.protocol === "https:"
+				) {
+					delete headers["referer"];
+				} else {
+					headers["referer"] = referrerUrl.origin;
+				}
+			}
+		}
+	}
+	if (
+		typeof headers["sec-fetch-site"] === "string" &&
+		headers["sec-fetch-site"] !== "none"
+	) {
+		if (typeof headers["referer"] === "string") {
+			headers["sec-fetch-site"] = await getSiteDirective(
+				meta,
+				new URL(headers["referer"]),
+				client
+			);
+		} else {
+			console.warn(
+				"Missing referrer header; can't rewrite sec-fetch-site properly. Falling back to unsafe deletion."
+			);
+			delete headers["sec-fetch-site"];
+		}
 	}
 
 	return headers;

--- a/src/shared/security/siteTests.ts
+++ b/src/shared/security/siteTests.ts
@@ -1,0 +1,188 @@
+import { type URLMeta } from "../rewriters/url";
+import IDBMap from "@webreflection/idb-map";
+
+import type {
+	default as BareClient,
+	BareResponseFetch,
+} from "@mercuryworkshop/bare-mux";
+
+// Cache every hour
+const CACHE_DURATION_MINUTES = 60;
+const CACHE_KEY = "$scramjet-public-suffix-list";
+
+const publicSuffixCache = new IDBMap<
+	string,
+	{ data: string[]; expiry: number }
+>();
+
+/**
+ * Emulate `Sec-Fetch-Site` header using the referrer (another reason why Force Referrer is now a needed SJ feature)
+ */
+export async function getSiteDirective(
+	meta: URLMeta,
+	referrerURL: URL,
+	client: BareClient
+): Promise<string> {
+	if (!referrerURL) {
+		return "none";
+	}
+
+	if (meta.origin.origin === referrerURL.origin) {
+		return "same-origin";
+	}
+
+	const sameSite = await isSameSite(meta.origin, referrerURL, client);
+	if (sameSite) {
+		return "same-site";
+	}
+
+	return "cross-site";
+}
+
+/**
+ * Tests if the two URLs are from the same site.
+ * This will be used in the response header rewriter.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Site
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site#directives
+ *
+ * @param url1 First URL to compare
+ * @param url2 Second URL to compare
+ * @param client `BareClient` instance used for fetching
+ * @returns Whether the two URLs are from the same site
+ *
+ * @throws {Error} If an error occurs while getting the Public Suffix List
+ */
+export async function isSameSite(
+	url1: URL,
+	url2: URL,
+	client: BareClient
+): Promise<boolean> {
+	const registrableDomain1 = await getRegistrableDomain(url1, client);
+	const registrableDomain2 = await getRegistrableDomain(url2, client);
+
+	return registrableDomain1 === registrableDomain2;
+}
+
+/**
+ * Gets the registrable domain (eTLD+1) for a URL
+ * @param url URL to get registrable domain for
+ * @param client `BareClient` instance for fetching public suffix list
+ * @returns Registrable domain
+ */
+async function getRegistrableDomain(
+	url: URL,
+	client: BareClient
+): Promise<string> {
+	const publicSuffixes = await getPublicSuffixList(client);
+
+	const hostname = url.hostname.toLowerCase();
+	const labels = hostname.split(".");
+	let matchedSuffix = "";
+
+	let isException = false;
+	for (const suffix of publicSuffixes) {
+		const actualSuffix = suffix.startsWith("!") ? suffix.substring(1) : suffix;
+		const suffixLabels = actualSuffix.split(".");
+
+		if (matchesSuffix(labels, suffixLabels)) {
+			if (suffix.startsWith("!")) {
+				matchedSuffix = actualSuffix;
+				isException = true;
+				break;
+			}
+			if (!isException && actualSuffix.length > matchedSuffix.length) {
+				matchedSuffix = actualSuffix;
+			}
+		}
+	}
+
+	if (!matchedSuffix) {
+		return labels.slice(-2).join(".");
+	}
+
+	const suffixLabelCount = matchedSuffix.split(".").length;
+	const domainLabelCount = isException
+		? suffixLabelCount
+		: suffixLabelCount + 1;
+
+	return labels.slice(-domainLabelCount).join(".");
+}
+
+/**
+ * Checks if hostname labels match a suffix pattern
+ * @param hostnameLabels Labels of the hostname (split by `.`)
+ * @param suffixLabels Labels of the suffix pattern (split by `.`)
+ * @returns Whether the hostname matches the suffix
+ */
+function matchesSuffix(
+	hostnameLabels: string[],
+	suffixLabels: string[]
+): boolean {
+	if (hostnameLabels.length < suffixLabels.length) {
+		return false;
+	}
+
+	const offset = hostnameLabels.length - suffixLabels.length;
+	for (let i = 0; i < suffixLabels.length; i++) {
+		const hostLabel = hostnameLabels[offset + i];
+		const suffixLabel = suffixLabels[i];
+
+		if (suffixLabel === "*") {
+			continue;
+		}
+
+		if (hostLabel !== suffixLabel) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Gets parsed Public Suffix list from the API.
+ *
+ * Complies with the standard format.
+ * @see https://github.com/publicsuffix/list/wiki/Format#format
+ *
+ * @param {BareClient} client `BareClient` instance used for fetching
+ * @returns {Promise<string[]>} Parsed Public Suffix list
+ *
+ * @throws {Error} If an error occurs while fetching from the Public Suffix List
+ */
+export async function getPublicSuffixList(
+	client: BareClient
+): Promise<string[]> {
+	const cached = await publicSuffixCache.get(CACHE_KEY);
+	if (cached && Date.now() < cached.expiry) {
+		return cached.data;
+	}
+
+	let publicSuffixesResponse: BareResponseFetch;
+	try {
+		publicSuffixesResponse = await client.fetch(
+			"https://publicsuffix.org/list/public_suffix_list.dat"
+		);
+	} catch (err) {
+		throw new Error(`Failed to fetch public suffix list: ${err}`);
+	}
+	const publicSuffixesRaw = await publicSuffixesResponse.text();
+
+	const publicSuffixes = publicSuffixesRaw
+		.split("\n")
+		.map((line) => {
+			const trimmed = line.trim();
+			const spaceIndex = trimmed.indexOf(" ");
+
+			return spaceIndex > -1 ? trimmed.substring(0, spaceIndex) : trimmed;
+		})
+		.filter((line) => line && !line.startsWith("//"));
+
+	await publicSuffixCache.set(CACHE_KEY, {
+		data: publicSuffixes,
+		expiry: Date.now() + CACHE_DURATION_MINUTES * 60 * 1000,
+	});
+
+	return publicSuffixes;
+}


### PR DESCRIPTION
This is a Draft PR because [specific WPT tests](https://wpt.live/fetch/metadata/generated/fetch.https.sub.html) fail, particularly those where the emulated referrer policy isn't being tracked on redirect navigations, hindering support for [WhatsApp Web](https://web.whatsapp.com). I will solve this by updating the recorded referrer policy throughout redirect chains.