### PR TITLE
fix: improved psl fetching

### DIFF
--- a/src/shared/security/siteTests.ts
+++ b/src/shared/security/siteTests.ts
@@ -235,7 +235,7 @@ let pslPromise: Promise<string[]> | undefined;
  *
  * @throws {Error} If an error occurs while fetching from the Public Suffix List
  */
-export async function getPublicSuffixList(
+export function getPublicSuffixList(
 	client: BareClient
 ): Promise<string[]> {
 	if (pslPromise) {


### PR DESCRIPTION
many tweaks to improve speed:
- prefer fetching directly over via proxy
- prefer using cached version up to 24 hours (the canonical max age)
- prefer using same as parallel psl fetcher instead of refetching

also error in case response isn't ok (best practice)