### PR TITLE
fix(css): rewrite @import URL rewriter

### DIFF
--- a/src/shared/rewriters/css.ts
+++ b/src/shared/rewriters/css.ts
@@ -11,36 +11,70 @@ export function unrewriteCss(css: string) {
 function handleCss(type: "rewrite" | "unrewrite", css: string, meta?: URLMeta) {
 	// regex from vk6 (https://github.com/ading2210)
 	const urlRegex = /url\(['"]?(.+?)['"]?\)/gm;
-	const Atruleregex =
-		/@import\s+(url\s*?\(.{0,9999}?\)|['"].{0,9999}?['"]|.{0,9999}?)($|\s|;)/gm;
 	css = new String(css).toString();
 	css = css.replace(urlRegex, (match, url) => {
-		const encodedUrl =
-			type === "rewrite"
-				? rewriteUrl(url.trim(), meta)
-				: unrewriteUrl(url.trim());
+		const encodedUrl = rewriteCssUrl(type, url, meta);
 
 		return match.replace(url, encodedUrl);
 	});
-	css = css.replace(Atruleregex, (match, importStatement) => {
-		return match.replace(
-			importStatement,
-			importStatement.replace(
-				/^(url\(['"]?|['"]|)(.+?)(['"]|['"]?\)|)$/gm,
-				(match, firstQuote, url, endQuote) => {
-					if (firstQuote.startsWith("url")) {
-						return match;
-					}
-					const encodedUrl =
-						type === "rewrite"
-							? rewriteUrl(url.trim(), meta)
-							: unrewriteUrl(url.trim());
+	css = css.replace(
+		/@import(\s+)([^;\n]+)(;?)/gm,
+		(match, whitespace, clause, semicolon) => {
+			const rewrittenClause = rewriteImportClause(type, clause, meta);
+			if (!rewrittenClause) return match;
 
-					return `${firstQuote}${encodedUrl}${endQuote}`;
-				}
-			)
-		);
-	});
+			return `@import${whitespace}${rewrittenClause}${semicolon}`;
+		}
+	);
 
 	return css;
+}
+
+function rewriteCssUrl(
+	type: "rewrite" | "unrewrite",
+	url: string,
+	meta?: URLMeta
+) {
+	return type === "rewrite"
+		? rewriteUrl(url.trim(), meta)
+		: unrewriteUrl(url.trim());
+}
+
+function rewriteImportClause(
+	type: "rewrite" | "unrewrite",
+	clause: string,
+	meta?: URLMeta
+) {
+	const urlImportMatch = clause.match(
+		/^url\(\s*(["']?)(.+?)\1\s*\)([\s\S]*)$/i
+	);
+	if (urlImportMatch) {
+		const quote = urlImportMatch[1] || "";
+		const url = urlImportMatch[2];
+		const remainder = urlImportMatch[3] || "";
+		const rewritten = rewriteCssUrl(type, url, meta);
+
+		return `url(${quote}${rewritten}${quote})${remainder}`;
+	}
+
+	const quotedImportMatch = clause.match(/^(['"])(.+?)\1([\s\S]*)$/);
+	if (quotedImportMatch) {
+		const quote = quotedImportMatch[1];
+		const url = quotedImportMatch[2];
+		const remainder = quotedImportMatch[3] || "";
+		const rewritten = rewriteCssUrl(type, url, meta);
+
+		return `${quote}${rewritten}${quote}${remainder}`;
+	}
+
+	const bareImportMatch = clause.match(/^(\S+)([\s\S]*)$/);
+	if (bareImportMatch) {
+		const url = bareImportMatch[1];
+		const remainder = bareImportMatch[2] || "";
+		const rewritten = rewriteCssUrl(type, url, meta);
+
+		return `${rewritten}${remainder}`;
+	}
+
+	return null;
 }


### PR DESCRIPTION
Fixes #135

The old `@import` regex used `.{0,9999}` length limits and a nested regex to re-parse the captured group, which mangled `@import` rules that had layer declarations or media queries after the URL (e.g. `@import url("foo.css") layer(default)`), causing broken layout on sites like Google AI Overview.

**Changes:**
- Simpler outer regex captures the full clause between `@import` and `;`/newline
- New `rewriteImportClause` helper correctly handles all three URL forms: `url(...)`, `"..."`, and bare
- Trailing layer/media/supports conditions after the URL are preserved
- Stops at newlines to prevent swallowing subsequent rules when a semicolon is missing

**Tradeoffs:**
- `@import` rules split across multiple lines (URL on one line, media query on the next) will lose the media query rewrite — only the URL line is captured. This is technically valid CSS but extremely rare in practice, and the spec strongly implies single-line `@import`.