### PR TITLE
fix rspack build when running in environment without git

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -157,7 +157,7 @@ const createScramjetConfig = (options) => {
 
 						return hash;
 					} catch {
-						return "unknown";
+						return JSON.stringify("unknown");
 					}
 				})(),
 			}),


### PR DESCRIPTION
In the rspack config:
https://github.com/MercuryWorkshop/scramjet/blob/b031dc0d056df7be36af2b94e8d2ca7021c69369/rspack.config.ts#L149-L163
The catch block returns the string `"unknown"` instead of `JSON.stringify("unknown")`. The unescaped value causes `unknown` to be inlined into the output JS, which is an invalid identifier. This fails in all environments without git or the .git folder.
