### PR TITLE
[scramjet/core] use native Uint8Array.toBase64 if present

### DIFF
--- a/packages/core/src/client/dom/element.ts
+++ b/packages/core/src/client/dom/element.ts
@@ -1,13 +1,12 @@
 import { htmlRules } from "@/shared/htmlRules";
 import {
 	String,
-	Array_from,
 	TextEncoder_encode,
-	btoa,
 	Object_keys,
 	Object_defineProperty,
 	atob,
 } from "@/shared/snapshot";
+import { bytesToBase64 } from "@/shared/util";
 import { rewriteCss, unrewriteCss } from "@rewriters/css";
 import { rewriteHtml, unrewriteHtml } from "@rewriters/html";
 import { rewriteJs } from "@rewriters/js";
@@ -16,14 +15,6 @@ import { SCRAMJETCLIENT } from "@/symbols";
 import { ScramjetClient } from "@client/index";
 import { isHtmlMimeType } from "@/shared/mime";
 import { ForeignContext } from "@/shared/rewriters/html";
-
-function bytesToBase64(bytes: Uint8Array) {
-	const binString = Array_from(bytes, (byte) =>
-		String.fromCodePoint(byte)
-	).join("");
-
-	return btoa(binString);
-}
 
 export function foreignContextForElement(
 	client: ScramjetClient,

--- a/packages/core/src/shared/rewriters/html.ts
+++ b/packages/core/src/shared/rewriters/html.ts
@@ -7,6 +7,7 @@ import { rewriteJs } from "@rewriters/js";
 import { ScramjetContext } from "@/shared";
 import { htmlRules } from "@/shared/htmlRules";
 import { parseDeclarativeRefresh } from "@/shared/refresh";
+import { bytesToBase64 } from "@/shared/util";
 import { Tap } from "@/Tap";
 import { RawHeaders } from "@mercuryworkshop/proxy-transports";
 import { TrackedHistoryState } from "@/fetch";
@@ -492,13 +493,6 @@ export function rewriteSrcset(
 // 	return Uint8Array.from(binString, (m) => m.codePointAt(0));
 // }
 
-function bytesToBase64(bytes: Uint8Array) {
-	const binString = Array_from(bytes, (byte) =>
-		String_fromCodePoint(byte)
-	).join("");
-
-	return btoa(binString);
-}
 const eventAttributes = [
 	"onbeforexrselect",
 	"onabort",

--- a/packages/core/src/shared/util.ts
+++ b/packages/core/src/shared/util.ts
@@ -1,8 +1,26 @@
 import {
+	Array_from,
 	btoa,
 	TextEncoder_encode,
 	String_fromCharCode,
+	String_fromCodePoint,
 } from "@/shared/snapshot";
+
+function bytesToBase64Fallback(bytes: Uint8Array): string {
+	const binString = Array_from(bytes, (byte) =>
+		String_fromCodePoint(byte)
+	).join("");
+
+	return btoa(binString);
+}
+
+const bytesToBase64Native: ((this: Uint8Array) => string) | undefined =
+	(Uint8Array.prototype as any).toBase64;
+
+export const bytesToBase64: (bytes: Uint8Array) => string =
+	typeof bytesToBase64Native === "function"
+		? (bytes) => bytesToBase64Native.call(bytes)
+		: bytesToBase64Fallback;
 
 export function base64Encode(text: string) {
 	return btoa(


### PR DESCRIPTION
`Uint8Array.toBase64` is now [available in most places](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64#browser_compatibility) and is part of baseline 2025, as well as being much more performant. This consolidates both `bytesToBase64` functions in the code as a new function that uses `Uint8Array.toBase64` but falls back on the previous implementation

Testing on cnn.com
Before:
<img width="793" height="142" alt="image" src="https://github.com/user-attachments/assets/a696ef25-356b-4115-b1b1-f5fda503bf5c" />
After:
<img width="760" height="139" alt="image" src="https://github.com/user-attachments/assets/2ee434b5-36d3-460c-a8d3-975a58f509f7" />

JSBench results
<img width="964" height="477" alt="image" src="https://github.com/user-attachments/assets/ff916cc8-1f17-4fdb-af75-ad5decdc1947" />
