### PR TITLE
[scramjet/core/rewriter] fix rewriter build

### DIFF
--- a/packages/core/rewriter/wasm/build.sh
+++ b/packages/core/rewriter/wasm/build.sh
@@ -34,7 +34,7 @@ if ! [[ "$(wasm-bindgen -V)" =~ ^"$WBG" ]]; then
 fi
 
 (
-	export RUSTFLAGS='-Zlocation-detail=none -Zfmt-debug=none'
+	export RUSTFLAGS='-Zlocation-detail=none -Zfmt-debug=none -C target-feature=-reference-types'
 	if [ "${OPTIMIZE_FOR_SIZE:-0}" = "1" ]; then
 		export RUSTFLAGS="${RUSTFLAGS} -C opt-level=z"
 	fi


### PR DESCRIPTION
fixed a build error where wasm-snip didn't like some new wasm features. I disabled reference-types to fix it.