### PR TITLE
[scramjet/core] don't include referrerPolicy query param when rewriting ES module URLs

### DIFF
--- a/packages/core/src/shared/rewriters/url.ts
+++ b/packages/core/src/shared/rewriters/url.ts
@@ -172,7 +172,7 @@ export function rewriteUrl(
 
 		const paramsInit = new _URLSearchParams();
 
-		const referrerPolicy = options?.referrerPolicy ?? meta.referrerPolicy;
+		const referrerPolicy = !options?.isModule && (options?.referrerPolicy ?? meta.referrerPolicy);
 		if (referrerPolicy) paramsInit.set(QP.referrerPolicy, referrerPolicy);
 		if (options?.isModule) paramsInit.set(QP.isModule, "module");
 		if (options?.topFrame) paramsInit.set(QP.topFrame, options.topFrame);


### PR DESCRIPTION
If a page has something like this:
```html
<script type="module" src="./tracked.js"></script>
<script type="module">await import("./tracked.js")</script>
```
`tracked.js`, as an ES module, should only be executed once, since it's the same URL. However, if `Referrer-Policy` is set to any value by the server, scramjet produces two different proxied URLs for ./tracked.js, depending on which rewriter was rewriting:
- The HTML rewriter would rewrite it as `./tracked.js?$module=module&$io=...`
- The URL rewriter would rewrite it as `./tracked.js?$rfp=same-origin&$module=module&$io=...`

This is because the referrer policy has not yet been populated when the HTML rewriter is rewriting. Since it rewrites as two different URLs, the module executes twice rather than once. For example, this causes React Router v7 to break. This PR strips the `$rfp` query parameter when rewriting ES module URLs.

You can use this test server to view the difference between the browser, scramjet, and this PR here:
[tracked.js](https://github.com/user-attachments/files/28241658/tracked.js) [index.html](https://github.com/user-attachments/files/28241659/index.html) [server.js](https://github.com/user-attachments/files/28241663/server.js) To run, download all into a folder and run "node server.js". For all the files together it's something like 20LOC
Browser:
<img width="242" height="48" alt="image" src="https://github.com/user-attachments/assets/79448794-1d65-4e8a-afd0-0a989ce09031" />
Current Scramjet:
<img width="308" height="50" alt="image" src="https://github.com/user-attachments/assets/418652c8-b455-4cc0-8a08-2849224c953c" />

If you would like to test it in action, go to https://play.xbox.com:
Current Scramjet:
<img width="2361" height="703" alt="image" src="https://github.com/user-attachments/assets/aa01cc9f-0755-47f7-9d1f-d671f429f82c" />
PR:
<img width="2293" height="979" alt="image" src="https://github.com/user-attachments/assets/21b704de-9c9a-43a8-82fe-05df3ad5a44d" />
