### PR TITLE
add family-friendly error screen back

### DIFF
--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -201,7 +201,6 @@ export async function route(event: FetchEvent): Promise<Response> {
 			headers: response.headers,
 		});
 	} catch (e) {
-		const client = await clients.get(event.clientId);
 		console.error("Service Worker error:", e);
 		return new Response(
 			`<!DOCTYPE html>
@@ -335,7 +334,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         <div id="info">
                             <div id="errorTrace-wrapper">
                                 <textarea id="errorTrace" cols="40" rows="10" readonly>Internal SW Error: ${(e as Error).message}</textarea>
-                                <button id="copy-button" class="primary">Copy</button>
+                                <button id="copy-button" class="primary" onclick="copyError()">Copy</button>
                             </div>
                             <div id="troubleshooting">
                                 <p>Try:</p>
@@ -353,12 +352,19 @@ export async function route(event: FetchEvent): Promise<Response> {
                                     <li>Troubleshooting the error on the <a href="https://github.com/MercuryWorkshop/scramjet" target="_blank">GitHub repository</a></li>
                                 </ul>
                             </div>
+							<!--i wish i could add the proxy fail gif from tn, but then that would just be unprofessional - havi11368-->
                         </div>
                         <br>
-                        <button id="reload" class="primary">Reload</button>
+                        <button id="reload" class="primary" onclick="window.location.reload()">Reload</button>
                     </div>
                     <p id="version-wrapper"><i>Scramjet v<span id="version"></span> (build <span id="build"></span>)</i></p>
                 </body>
+				<script>
+					function copyError() {
+						navigator.clipboard.writeText(document.querySelector("#errorTrace").value)
+						document.querySelector("#copy-button").innerHTML = "Copied!"
+					}
+				</script>
             </html>`,
 			{
 				status: 500,

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -202,9 +202,165 @@ export async function route(event: FetchEvent): Promise<Response> {
 	} catch (e) {
 		console.error("Service Worker error:", e);
 		return new Response(
-			"Internal Service Worker Error: " + (e as Error).message,
+			`<!DOCTYPE html>
+            <html>
+                <head>
+                    <meta charset="utf-8" />
+                    <title>Scramjet</title>
+                    <style>
+                    :root {
+                        --deep: #080602;
+                        --shallow: #181412;
+                        --beach: #f1e8e1;
+                        --shore: #b1a8a1;
+                        --accent: #ffa938;
+                        --font-sans: -apple-system, system-ui, BlinkMacSystemFont, sans-serif;
+                        --font-monospace: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+                    }
+
+                    *:not(div,p,span,ul,li,i,span) {
+                        background-color: var(--deep);
+                        color: var(--beach);
+                        font-family: var(--font-sans);
+                    }
+
+                    textarea,
+                    button {
+                        background-color: var(--shallow);
+                        border-radius: 0.6em;
+                        padding: 0.6em;
+                        border: none;
+                        appearance: none;
+                        font-family: var(--font-sans);
+                        color: var(--beach);
+                    }
+
+                    button.primary {
+                        background-color: var(--accent);
+                        color: var(--deep);
+                        font-weight: bold;
+                    }
+
+                    textarea {
+                        resize: none;
+                        height: 20em;
+                        text-align: left;
+                        font-family: var(--font-monospace);
+                    }
+
+                    body {
+                        width: 100vw;
+                        height: 100vh;
+                        justify-content: center;
+                        align-items: center;
+                    }
+
+                    body,
+                    html,
+                    #inner {
+                        display: flex;
+                        align-items: center;
+                        flex-direction: column;
+                        gap: 0.5em;
+                        overflow: hidden;
+                    }
+
+                    #inner {
+                        z-index: 100;
+                    }
+
+                    #cover {
+                        position: absolute;
+                        width: 100%;
+                        height: 100%;
+                        background-color: color-mix(in srgb, var(--deep) 70%, transparent);
+                        z-index: 99;
+                    }
+
+                    #info {
+                        display: flex;
+                        flex-direction: row;
+                        align-items: flex-start;
+                        gap: 1em;
+                    }
+
+                    #version-wrapper {
+                        width: auto;
+                        text-align: right;
+                        position: absolute;
+                        top: 0.5rem;
+                        right: 0.5rem;
+                        font-size: 0.8rem;
+                        color: var(--shore)!important;
+                        i {
+                            background-color: color-mix(in srgb, var(--deep), transparent 50%);
+                            border-radius: 9999px;
+                            padding: 0.2em 0.5em;
+                        }
+                        z-index: 101;
+                    }
+
+                    #errorTrace-wrapper {
+                        position: relative;
+                        width: fit-content;
+                    }
+
+                    #copy-button {
+                        position: absolute;
+                        top: 0.5em;
+                        right: 0.5em;
+                        padding: 0.23em;
+                        cursor: pointer;
+                        opacity: 0;
+                        transition: opacity 0.4s;
+                        font-size: 0.9em;
+                    }
+
+                    #errorTrace-wrapper:hover #copy-button {
+                        opacity: 1;
+                    }
+                    </style>
+                </head>
+                <body>
+                    <div id="cover"></div>
+                    <div id="inner">
+                        <h1 id="errorTitle">Uh oh!</h1>
+                        <p>There was an error loading <b id="fetchedURL"></b></p>
+                        <!-- <p id="errorMessage">Internal Server Error</p> -->
+
+                        <div id="info">
+                            <div id="errorTrace-wrapper">
+                                <textarea id="errorTrace" cols="40" rows="10" readonly></textarea>
+                                <button id="copy-button" class="primary">Copy</button>
+                            </div>
+                            <div id="troubleshooting">
+                                <p>Try:</p>
+                                <ul>
+                                    <li>Checking your internet connection</li>
+                                    <li>Verifying you entered the correct address</li>
+                                    <li>Clearing the site data</li>
+                                    <li>Contacting <b id="hostname"></b>'s administrator</li>
+                                    <li>Verify the server isn't censored</li>
+                                </ul>
+                                <p>If you're the administrator of <b id="hostname"></b>, try:</p>
+                                    <ul>
+                                    <li>Restarting your server</li>
+                                    <li>Updating Scramjet</li>
+                                    <li>Troubleshooting the error on the <a href="https://github.com/MercuryWorkshop/scramjet" target="_blank">GitHub repository</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                        <br>
+                        <button id="reload" class="primary">Reload</button>
+                    </div>
+                    <p id="version-wrapper"><i>Scramjet v<span id="version"></span> (build <span id="build"></span>)</i></p>
+                </body>
+            </html>`,
 			{
 				status: 500,
+				headers: {
+    				'Content-Type': 'text/html; charset=utf-8'
+  				}
 			}
 		);
 	}

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -201,6 +201,7 @@ export async function route(event: FetchEvent): Promise<Response> {
 			headers: response.headers,
 		});
 	} catch (e) {
+		const client = await clients.get(event.clientId);
 		console.error("Service Worker error:", e);
 		return new Response(
 			`<!DOCTYPE html>
@@ -341,10 +342,10 @@ export async function route(event: FetchEvent): Promise<Response> {
                                     <li>Checking your internet connection</li>
                                     <li>Verifying you entered the correct address</li>
                                     <li>Clearing the site data</li>
-                                    <li>Contacting <b id="hostname"></b>'s administrator</li>
+                                    <li>Contacting <b id="hostname">${event.request.referrer}</b>'s administrator</li>
                                     <li>Verify the server isn't censored</li>
                                 </ul>
-                                <p>If you're the administrator of <b id="hostname"></b>, try:</p>
+                                <p>If you're the administrator of <b id="hostname">${event.request.referrer}</b>, try:</p>
                                     <ul>
                                     <li>Restarting your server</li>
                                     <li>Updating Scramjet</li>

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -3,6 +3,7 @@
 import { RpcHelper } from "@mercuryworkshop/rpc";
 import type { Controllerbound, SWbound } from "./types";
 import type { RawHeaders } from "@mercuryworkshop/proxy-transports";
+import { versionInfo } from "@mercuryworkshop/scramjet";
 
 function makeId(): string {
 	return Math.random().toString(36).substring(2, 10);
@@ -331,7 +332,7 @@ export async function route(event: FetchEvent): Promise<Response> {
 
                         <div id="info">
                             <div id="errorTrace-wrapper">
-                                <textarea id="errorTrace" cols="40" rows="10" readonly></textarea>
+                                <textarea id="errorTrace" cols="40" rows="10" readonly>Internal SW Error: ${(e as Error).message}</textarea>
                                 <button id="copy-button" class="primary">Copy</button>
                             </div>
                             <div id="troubleshooting">
@@ -354,7 +355,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         <br>
                         <button id="reload" class="primary">Reload</button>
                     </div>
-                    <p id="version-wrapper"><i>Scramjet v<span id="version"></span> (build <span id="build"></span>)</i></p>
+                    <p id="version-wrapper"><i>Scramjet v<span id="version">${versionInfo.version}</span> (build <span id="build">${versionInfo.build}</span>)</i></p>
                 </body>
             </html>`,
 			{

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -355,7 +355,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         <br>
                         <button id="reload" class="primary">Reload</button>
                     </div>
-                    <p id="version-wrapper"><i>Scramjet v<span id="version">${versionInfo.version}</span> (build <span id="build">${versionInfo.build}</span>)</i></p>
+                    <p id="version-wrapper"><i>Scramjet v<span id="version"></span> (build <span id="build"></span>)</i></p>
                 </body>
             </html>`,
 			{

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -3,8 +3,7 @@
 import { RpcHelper } from "@mercuryworkshop/rpc";
 import type { Controllerbound, SWbound } from "./types";
 import type { RawHeaders } from "@mercuryworkshop/proxy-transports";
-import { versionInfo } from "@mercuryworkshop/scramjet";
-
+import { VERSION } from "./version";
 function makeId(): string {
 	return Math.random().toString(36).substring(2, 10);
 }
@@ -357,7 +356,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         <br>
                         <button id="reload" class="primary" onclick="window.location.reload()">Reload</button>
                     </div>
-                    <p id="version-wrapper"><i>Scramjet v<span id="version"></span> (build <span id="build"></span>)</i></p>
+                    <p id="version-wrapper"><i>Scramjet Controller v<span id="version">${VERSION}</span></p>
                 </body>
 				<script>
 					function copyError() {

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -233,6 +233,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         appearance: none;
                         font-family: var(--font-sans);
                         color: var(--beach);
+						cursor: pointer;
                     }
 
                     button.primary {

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -249,6 +249,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                         height: 20em;
                         text-align: left;
                         font-family: var(--font-monospace);
+						cursor: text;
                     }
 
                     body {

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -328,7 +328,7 @@ export async function route(event: FetchEvent): Promise<Response> {
                     <div id="cover"></div>
                     <div id="inner">
                         <h1 id="errorTitle">Uh oh!</h1>
-                        <p>There was an error loading <b id="fetchedURL"></b></p>
+                        <p>There was an error loading <b id="fetchedURL">${decodeURIComponent(event.request.url.replace(event.request.referrer, "").slice(23))}</b></p>
                         <!-- <p id="errorMessage">Internal Server Error</p> -->
 
                         <div id="info">

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -342,10 +342,10 @@ export async function route(event: FetchEvent): Promise<Response> {
                                     <li>Checking your internet connection</li>
                                     <li>Verifying you entered the correct address</li>
                                     <li>Clearing the site data</li>
-                                    <li>Contacting <b id="hostname">${event.request.referrer}</b>'s administrator</li>
+                                    <li>Contacting <b id="hostname">${event.request.referrer.replace("http", "").replace("s:", "").replace(":", "").replaceAll("/", "")}</b>'s administrator</li>
                                     <li>Verify the server isn't censored</li>
                                 </ul>
-                                <p>If you're the administrator of <b id="hostname">${event.request.referrer}</b>, try:</p>
+                                <p>If you're the administrator of <b id="hostname">${event.request.referrer.replace("http", "").replace("s:", "").replace(":", "").replaceAll("/", "")}</b>, try:</p>
                                     <ul>
                                     <li>Restarting your server</li>
                                     <li>Updating Scramjet</li>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
 		"@eslint/js": "^9.35.0",
 		"@types/eslint": "^9.6.1",
 		"@types/estree": "^1.0.8",
-		"@types/node": "^24.3.1",
+		"@types/node": "^24.9.0",
 		"@types/serviceworker": "^0.0.197",
 		"@typescript-eslint/eslint-plugin": "8.62.0",
 		"@typescript-eslint/parser": "8.62.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       '@types/node':
-        specifier: ^24.3.1
+        specifier: ^24.9.0
         version: 24.9.0
       '@types/serviceworker':
         specifier: ^0.0.197
@@ -3195,6 +3195,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,19 @@ packages:
   - packages/bootstrap
   - packages/create-proxy-app
 
-overrides:
-  htmlparser2: 12.0.0
-  
 catalog:
-  "@mercuryworkshop/wisp-js": 0.4.1
-  "@mercuryworkshop/proxy-transports": 1.0.2
-  "@mercuryworkshop/libcurl-transport": 2.0.5
-  "@mercuryworkshop/epoxy-transport": 3.0.1
+  '@mercuryworkshop/wisp-js': 0.4.1
+  '@mercuryworkshop/proxy-transports': 1.0.2
+  '@mercuryworkshop/libcurl-transport': 2.0.5
+  '@mercuryworkshop/epoxy-transport': 3.0.1
+  htmlparser2: 12.0.0
+
+onlyBuiltDependencies:
+  - bufferutil
+  - core-js
+  - esbuild
+
+overrides:
   htmlparser2: 12.0.0
 
 patchedDependencies:


### PR DESCRIPTION
i noticed that someone removed the family-friendly error screen from the sw
so i added it back

current (hard to understand from a student's perspective):
<img width="1595" height="734" alt="image" src="https://github.com/user-attachments/assets/75e8254a-559b-45bf-b5c5-2fc2f3577ceb" />

incoming change:
<img width="1595" height="734" alt="image" src="https://github.com/user-attachments/assets/0f8a1eb6-8ae1-4434-8563-42db808da804" />

i also updated a package by accident