### PR TITLE
fix currentsrc leaking proxy url

### DIFF
--- a/packages/core/src/client/dom/element.ts
+++ b/packages/core/src/client/dom/element.ts
@@ -183,6 +183,26 @@ export default function (client: ScramjetClient, self: typeof window) {
 		}
 	}
 
+	const imageCurrentSrcDescriptor = client.natives.call(
+		"Object.getOwnPropertyDescriptor",
+		null,
+		self.HTMLImageElement.prototype,
+		"currentSrc"
+	);
+	Object_defineProperty(self.HTMLImageElement.prototype, "currentSrc", {
+		get() {
+			const original = client.natives.call(
+				"Element.prototype.getAttribute",
+				this,
+				"scramjet-attr-src"
+			);
+			if (original !== null) return original;
+			const currentSrc = imageCurrentSrcDescriptor.get.call(this);
+			if (!currentSrc) return currentSrc;
+			return unrewriteUrl(currentSrc, client.context);
+		},
+	});
+
 	// note that href is not here
 	const urlprops = [
 		"protocol",


### PR DESCRIPTION
If a script did something like 

`
const img = document.createElement("img");
img.src = "https://picsum.photos/200?random=" + Math.random();
img.onload = () => {
    console.log("Loaded image src:", img.currentSrc);
};
`

img.currentSrc would leak the proxy url. This commit fixes that and unwrites the url fixing the issue.

Demo url: https://bearcattt.github.io/origin-test/