### PR TITLE
fix: coerce attribute and header names to string before toLowerCase

### DIFF
--- a/packages/core/src/client/dom/element.ts
+++ b/packages/core/src/client/dom/element.ts
@@ -292,6 +292,11 @@ export default function (client: ScramjetClient, self: typeof window) {
 			let [name, value] = ctx.args;
 			const tagName = ctx.this.tagName.toLowerCase();
 
+			// setAttribute() stringifies its arguments, so callers are free to pass a non-string
+			// name (e.g. setAttribute(123, "x")). Coerce it the same way the DOM does, otherwise
+			// name.toLowerCase() below throws and takes the whole page down.
+			name = String(name);
+			ctx.args[0] = name;
 			if (value != null) value = String(value);
 			ctx.args[1] = value;
 

--- a/packages/core/src/client/shared/requests/xmlhttprequest.ts
+++ b/packages/core/src/client/shared/requests/xmlhttprequest.ts
@@ -148,7 +148,9 @@ export default function (client: ScramjetClient, self: Self) {
 		apply(ctx) {
 			const header = ctx.fn.call(ctx.this, ctx.args[0]) as string | null;
 			if (!header) return header;
-			if (ctx.args[0].toLowerCase() === "link") {
+			// same as setAttribute: the header name is stringified by the platform, so it may
+			// arrive as a non-string and .toLowerCase() would throw
+			if (String(ctx.args[0]).toLowerCase() === "link") {
 				ctx.return(unrewriteLinkHeader(header, client.context));
 			}
 		},


### PR DESCRIPTION
Fixes #184.

`Element.prototype.setAttribute` and `XMLHttpRequest.prototype.getResponseHeader` stringify their
name argument at the platform level, so callers may legitimately pass a non-string:
`el.setAttribute(123, "x")` works fine natively.

Both proxies called `.toLowerCase()` on the raw argument, so such a call threw

```
TypeError: r.toLowerCase is not a function
```

and — because it happens inside the proxy — took down the whole page rather than just that call.

This is not hypothetical: two game platforms we proxy (Spinomenal and Retro Gaming, sharing an SDK)
do exactly this inside their element factory. Their games rendered nothing at all until we patched
it locally; with the coercion they load normally.

The change coerces with `String()` right next to the existing `String(value)` coercion, and writes
the normalized name back to `ctx.args[0]` so the underlying call sees the same value the rule lookup
used.