### PR TITLE
fix(rewriter): separate inserted wrappers from a preceding keyword

### DIFF
--- a/packages/core/rewriter/js/src/changes.rs
+++ b/packages/core/rewriter/js/src/changes.rs
@@ -152,7 +152,8 @@ impl<'alloc: 'data, 'data> Transform<'data> for JsChange<'alloc, 'data> {
 			} else {
 				transforms![")"]
 			}),
-			Ty::WrapPropertyLeft => LL::insert(transforms![&cfg.wrappropertyfn, "(("]),
+			// same hazard as WrapPostMessageLeft above
+			Ty::WrapPropertyLeft => LL::insert(transforms![" ", &cfg.wrappropertyfn, "(("]),
 			Ty::WrapPropertyRight => LL::insert(transforms!["))"]),
 			Ty::RewriteProperty { ident } => LL::replace(transforms![&cfg.wrappropertybase, ident]),
 			Ty::RebindProperty { ident, tempvar } => {
@@ -249,7 +250,11 @@ impl<'alloc: 'data, 'data> Transform<'data> for JsChange<'alloc, 'data> {
 					LL::insert(transforms![",", &cfg.tempunusedid, "=(", &steps, "0)"])
 				}
 			}
-			Ty::WrapPostMessageLeft => LL::insert(transforms![&cfg.wrappostmessagefn, "("]),
+			// The insert point is the start of an arbitrary expression, which in minified code can
+			// sit directly after a keyword (`typeof(x).postMessage`). Without a separator the
+			// wrapper name glues to it and the result lexes as a single identifier
+			// (`typeof$wrapPostMessage`). Same reason `$scramitize` below is emitted with a space.
+			Ty::WrapPostMessageLeft => LL::insert(transforms![" ", &cfg.wrappostmessagefn, "("]),
 			Ty::ScramErrFn { ident } => LL::insert(transforms!["$scramerr(", ident, ");"]),
 			Ty::ScramitizeFn => LL::insert(transforms![" $scramitize("]),
 			Ty::EvalRewriteFn => LL::insert(transforms![&cfg.rewritefn, "("]),


### PR DESCRIPTION
Fixes #185.

`WrapPostMessageLeft` and `WrapPropertyLeft` insert their wrapper at the start of an arbitrary
expression. In minified input that position can sit immediately after a keyword:

```js
if ("function" != typeof(this.incomingTarget = i).postMessage)
    throw new Error("The window.postMessage() function is not supported!");
```

The emitted wrapper glues to the keyword:

```js
if ("function" != typeof$wrapPostMessage((this.incomingTarget = i)).postMessage)
```

`typeof$wrapPostMessage` lexes as a single identifier, so the script dies with
`ReferenceError: typeof$scramjet$wrappostmessage is not defined` and the page never initialises.
We hit this on a production game bundle (Novomatic/Greentube): the engine did not start at all.

The patch emits a leading space, which is exactly what `ScramitizeFn` right below already does for
the same reason — so this follows existing convention in the file rather than introducing a new one.

Note on verification: I don't have the Rust/wasm toolchain set up, so I have not built the rewriter
locally. What I did verify is the equivalent transformation applied to the rewriter's output
(inserting a space between the keyword and the wrapper) — with it the affected game loads and plays
normally, without it the engine throws at construction. Happy to adjust if you'd prefer the
separator only in the cases where the preceding character can start an identifier.