### PR TITLE
fix(controller): stream the response body over a port where streams can't be transferred

### DIFF
--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -20,6 +20,12 @@ import {
 	type TrackedHistoryState,
 	Plugin,
 } from "@mercuryworkshop/scramjet";
+import {
+	CHUNKED_STREAM,
+	canTransferStream,
+	chunkedStreamOf,
+	isChunkedStream,
+} from "./streamfallback";
 import { CONTROLLERFRAME } from "./symbols";
 import type {
 	FrameInitHooks,
@@ -323,17 +329,27 @@ export class Controller {
 					clientId: data.clientId,
 				});
 
+				// Safari can't transfer a ReadableStream, so hand over a port and pump the body
+				// through it instead of failing outright. See streamfallback.ts.
+				const body =
+					fetchresponse.body instanceof ReadableStream && !canTransferStream()
+						? chunkedStreamOf(
+								fetchresponse.body as ReadableStream<Uint8Array>
+							)
+						: fetchresponse.body;
+
 				return [
 					{
-						body: fetchresponse.body,
+						body,
 						status: fetchresponse.status,
 						statusText: fetchresponse.statusText,
 						headers: fetchresponse.headers.toRawHeaders(),
 					},
-					fetchresponse.body instanceof ReadableStream ||
-					fetchresponse.body instanceof ArrayBuffer
-						? [fetchresponse.body]
-						: [],
+					isChunkedStream(body)
+						? [body[CHUNKED_STREAM]]
+						: body instanceof ReadableStream || body instanceof ArrayBuffer
+							? [body]
+							: [],
 				];
 			} catch (e) {
 				const reqcontext: typeof frame.hooks.error.request.context = {

--- a/packages/controller/src/streamfallback.ts
+++ b/packages/controller/src/streamfallback.ts
@@ -1,0 +1,146 @@
+/**
+ * Fallback for browsers that can't transfer a ReadableStream over a MessagePort.
+ *
+ * Safari doesn't implement transferable streams: putting a ReadableStream in the transfer list
+ * throws DataCloneError, the response never reaches the service worker, and nothing loads at all.
+ * ArrayBuffer, on the other hand, transfers everywhere — so instead of the stream itself we hand
+ * over a MessagePort and pump the body through it chunk by chunk.
+ *
+ * Backpressure is pull-based on purpose: a chunk is only sent in response to a request from the
+ * receiving side. Without that, a fast upstream and a slow consumer fill the message queue, and the
+ * symptom is a page that silently stalls halfway through loading.
+ *
+ * Browsers that can transfer streams never enter this path.
+ */
+
+export const CHUNKED_STREAM = "__chunkedStream";
+
+export type ChunkedStream = { [CHUNKED_STREAM]: MessagePort };
+
+let canTransfer: boolean | undefined;
+
+export function canTransferStream(): boolean {
+	if (canTransfer === undefined) {
+		try {
+			const stream = new ReadableStream();
+			const { port1 } = new MessageChannel();
+			port1.postMessage(stream, [stream as unknown as Transferable]);
+			canTransfer = true;
+		} catch {
+			canTransfer = false;
+		}
+	}
+
+	return canTransfer;
+}
+
+export function isChunkedStream(body: unknown): body is ChunkedStream {
+	return (
+		typeof body === "object" &&
+		body !== null &&
+		CHUNKED_STREAM in body &&
+		(body as ChunkedStream)[CHUNKED_STREAM] instanceof MessagePort
+	);
+}
+
+/** Sender side: hands out one chunk per request from the receiver. */
+export function chunkedStreamOf(
+	stream: ReadableStream<Uint8Array>
+): ChunkedStream {
+	const { port1, port2 } = new MessageChannel();
+	const reader = stream.getReader();
+
+	const finish = (message: Record<string, unknown>) => {
+		try {
+			port1.postMessage(message);
+		} catch {}
+		try {
+			port1.close();
+		} catch {}
+	};
+
+	port1.onmessage = async (e: MessageEvent) => {
+		if (e.data === "cancel") {
+			try {
+				await reader.cancel();
+			} catch {}
+			try {
+				port1.close();
+			} catch {}
+
+			return;
+		}
+
+		try {
+			const { value, done } = await reader.read();
+			if (done || !value) return finish({ done: true });
+
+			// Only a whole buffer can be transferred. A reader hands out a view that often looks at
+			// part of a larger buffer — copy that part out, otherwise neighbouring chunks that
+			// haven't been read yet would be detached along with it.
+			const exact =
+				value.byteOffset === 0 && value.byteLength === value.buffer.byteLength;
+			const buffer = exact ? value.buffer : value.slice().buffer;
+			port1.postMessage({ chunk: buffer }, [buffer as Transferable]);
+		} catch (err) {
+			finish({ error: String((err as Error)?.message || err) });
+		}
+	};
+	port1.start();
+
+	return { [CHUNKED_STREAM]: port2 };
+}
+
+/** Receiver side: rebuilds the stream, asking for one chunk at a time. */
+export function streamOfChunked(port: MessagePort): ReadableStream<Uint8Array> {
+	let wake: (() => void) | null = null;
+	const nudge = () => {
+		const w = wake;
+		wake = null;
+		if (w) w();
+	};
+
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			port.onmessage = (e: MessageEvent) => {
+				const data = e.data || {};
+				try {
+					if (data.chunk) controller.enqueue(new Uint8Array(data.chunk));
+					else if (data.done) {
+						controller.close();
+						port.close();
+					} else if (data.error) {
+						controller.error(new Error(data.error));
+						port.close();
+					}
+				} catch {}
+				nudge();
+			};
+			port.onmessageerror = () => {
+				try {
+					controller.error(new Error("chunked stream: messageerror"));
+				} catch {}
+				nudge();
+			};
+			port.start();
+		},
+		pull() {
+			return new Promise<void>((resolve) => {
+				wake = resolve;
+				try {
+					port.postMessage("pull");
+				} catch {
+					nudge();
+				}
+			});
+		},
+		cancel() {
+			try {
+				port.postMessage("cancel");
+			} catch {}
+			try {
+				port.close();
+			} catch {}
+		},
+	});
+}

--- a/packages/controller/src/sw.ts
+++ b/packages/controller/src/sw.ts
@@ -3,6 +3,11 @@
 import { RpcHelper } from "@mercuryworkshop/rpc";
 import type { Controllerbound, SWbound } from "./types";
 import type { RawHeaders } from "@mercuryworkshop/proxy-transports";
+import {
+	CHUNKED_STREAM,
+	isChunkedStream,
+	streamOfChunked,
+} from "./streamfallback";
 
 function makeId(): string {
 	return Math.random().toString(36).substring(2, 10);
@@ -194,7 +199,13 @@ export async function route(event: FetchEvent): Promise<Response> {
 				: undefined
 		);
 
-		return new Response(response.body, {
+		// Where the stream couldn't be transferred, the controller sent a port instead — rebuild the
+		// stream from it so Response gets exactly what it gets everywhere else.
+		const body = isChunkedStream(response.body)
+			? streamOfChunked(response.body[CHUNKED_STREAM])
+			: response.body;
+
+		return new Response(body, {
 			status: response.status,
 			statusText: response.statusText,
 			headers: response.headers,

--- a/packages/controller/src/types.d.ts
+++ b/packages/controller/src/types.d.ts
@@ -1,11 +1,13 @@
 import type { RawHeaders } from "@mercuryworkshop/proxy-transports";
 import type { CONTROLLERFRAME } from "./symbols";
 import type { Frame } from ".";
+import type { ChunkedStream } from "./streamfallback";
 export type BodyType =
 	| string
 	| ArrayBuffer
 	| Blob
-	| ReadableStream<Uint8Array<ArrayBufferLike>>;
+	| ReadableStream<Uint8Array<ArrayBufferLike>>
+	| ChunkedStream;
 
 export type TransferRequest = {
 	rawUrl: string;


### PR DESCRIPTION
Fixes #192.

Safari doesn't implement transferable streams, so `fetchresponse.body` in the transfer list throws `DataCloneError`, the response never reaches the service worker, and nothing loads at all.

Feature-detect it once. Where the transfer isn't available, hand the service worker a `MessagePort` instead of the stream and pump the body through it a chunk at a time. Each chunk is an `ArrayBuffer`, which transfers everywhere, so it still moves without a copy — and the body stays a stream on both ends rather than being buffered whole.

Backpressure is pull-based: a chunk is sent only in response to a request from the receiving side. Without that, a fast upstream and a slow consumer fill the message queue and the page silently stalls halfway through loading.

Browsers that can transfer streams never enter the new path, so nothing changes for them.

### How I got here

I first shipped the obvious fallback downstream — `await new Response(body).arrayBuffer()` when the transfer throws. It works, but it drops streaming in Safari entirely: a 3 MB script reaches the service worker only after its last byte. Chunking over a port turned out to be about the same amount of code and keeps the stream.

What I measured in Safari 26.5.2 before writing it, since the whole idea rests on it:

```
transfer ReadableStream via MessageChannel   DataCloneError
transfer ReadableStream to Worker            DataCloneError
transfer MessagePort via MessageChannel      ok      <- transfer mechanism itself is fine
transfer ArrayBuffer via MessageChannel      ok      <- and it really detaches, so no copy
transfer 50 x 64KB ArrayBuffer to Worker     ok
```

Worth noting for anyone touching this later: `ReadableStream` *exists* in Safari, only its transfer doesn't, so a `"ReadableStream" in globalThis` style check won't catch it — it has to be a try/catch probe.

One detail that isn't obvious in the code: a reader hands out a `Uint8Array` view that often points at part of a larger buffer. Transferring `value.buffer` directly would detach neighbouring chunks that haven't been read yet, so the non-exact case is copied out first.

### Verification

Real Safari 26.5.2 via `safaridriver` (a Playwright WebKit build does *not* reproduce the original bug, so it can't confirm the fix either), plus Chrome 150 and Firefox 151.

I ran a set of 8 real sites through the proxy on the buffering build and on this one — identical results, same rendered output in every case. On ~3 MB bodies the time to interactive was the same within noise (4.3 s vs 4.3 s), which is expected: the win here is not allocating the whole body, not latency. It should matter more on large downloads and media.

`tsc -p packages/controller` reports the same 38 pre-existing errors as unmodified `main`, none in the touched files.
